### PR TITLE
接上一个pr继续

### DIFF
--- a/.github/workflows/creat-image.yml
+++ b/.github/workflows/creat-image.yml
@@ -11,11 +11,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        architecture: [linux/amd64, linux/arm64]
-
     steps:
+      - name: Check VISION secret
+        run: |
+          if [ -z "${{ secrets.VISION }}" ]; then
+            echo "Error: VISION secret is not set"
+            exit 1
+          fi
+
       - name: Check out the repository
         uses: actions/checkout@v2
 
@@ -31,25 +34,23 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push Docker image
-        if: env.VISION != '' && matrix.architecture == 'linux/amd64'
+      - name: Build and push Docker image (AMD64)
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           tags: |
-            chb2024/pieces-os:${{ env.VISION }}
+            chb2024/pieces-os:${{ secrets.VISION }}
             chb2024/pieces-os:latest
           platforms: linux/amd64
 
-      - name: Build and push ARM Docker image
-        if: env.VISION != '' && matrix.architecture == 'linux/arm64'
+      - name: Build and push Docker image (ARM64)
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           tags: |
-            chb2024/pieces-os-arm:${{ env.VISION }}
+            chb2024/pieces-os-arm:${{ secrets.VISION }}
             chb2024/pieces-os-arm:latest
           platforms: linux/arm64
 

--- a/.github/workflows/creat-image.yml
+++ b/.github/workflows/creat-image.yml
@@ -1,24 +1,57 @@
-name: Docker Image CI
+name: Build and Push Docker Image
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+  workflow_dispatch:
+  repository_dispatch:
+    types: [update]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: [linux/amd64, linux/arm64]
+
     steps:
-    - uses: actions/checkout@v4
-    - name: Extract version from package.json
-      id: extract_version  # 设置 ID 以便后续步骤引用
-      run: |
-        VERSION=$(jq -r '.version' package.json)
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag chb2024/pieces-os:${{ steps.extract_version.outputs.version }} --tag chb2024/pieces-os:latest
-    - name: Log in to Docker Hub
-      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-    - name: Push the Docker image with version tag
-      run: docker push chb2024/pieces-os:${{ steps.extract_version.outputs.version }}
-    - name: Push the Docker image with latest tag
-      run: docker push chb2024/pieces-os:latest
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        if: env.VISION != '' && matrix.architecture == 'linux/amd64'
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            chb2024/pieces-os:${{ env.VISION }}
+            chb2024/pieces-os:latest
+          platforms: linux/amd64
+
+      - name: Build and push ARM Docker image
+        if: env.VISION != '' && matrix.architecture == 'linux/arm64'
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            chb2024/pieces-os-arm:${{ env.VISION }}
+            chb2024/pieces-os-arm:latest
+          platforms: linux/arm64
+
+      - name: Notify on success
+        run: echo "Docker image built and pushed successfully."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 使用 Node.js 20 作为基础镜像
-FROM node:20
+FROM node:20-alpine
 
 # 设置工作目录
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# 使用 Node.js 18 作为基础镜像
-FROM node:18-slim
+# 使用 Node.js 20 作为基础镜像
+FROM node:20
 
 # 设置工作目录
 WORKDIR /usr/src/app
@@ -7,14 +7,14 @@ WORKDIR /usr/src/app
 # 复制 package.json 和 package-lock.json
 COPY package*.json ./
 
-# 安装依赖
+# 安装生产环境依赖
 RUN npm ci --only=production
 
 # 复制应用程序代码
 COPY . .
 
-# 暴露端口（根据您的应用设置）
+# 暴露端口（根据应用需要）
 EXPOSE 8787
 
-# 运行应用
-CMD ["node", "api/index.js"]
+# 启动应用和健康检查
+CMD ["sh", "-c", "node api/index.js & node healthCheck.js && wait"]

--- a/healthCheck.js
+++ b/healthCheck.js
@@ -1,0 +1,39 @@
+import http from 'http';
+import { exec } from 'child_process';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const PORT_TO_CHECK = 8787;
+const CHECK_INTERVAL = (process.env.CHECK_INTERVAL || 60) * 1000; // 默认60秒，转换为毫秒
+
+function checkPort() {
+  console.log(`[${new Date().toISOString()}] 正在检查端口 ${PORT_TO_CHECK}...`);
+  
+  http.get(`http://localhost:${PORT_TO_CHECK}`, (res) => {
+    if (res.statusCode === 200 || res.statusCode === 401) {
+      console.log(`[${new Date().toISOString()}] 端口 ${PORT_TO_CHECK} 响应正常。`);
+    } else {
+      console.log(`[${new Date().toISOString()}] 端口 ${PORT_TO_CHECK} 响应异常，状态码: ${res.statusCode}`);
+      restartApp();
+    }
+  }).on('error', (err) => {
+    console.error(`[${new Date().toISOString()}] 检查端口 ${PORT_TO_CHECK} 时发生错误:`, err.message);
+    restartApp();
+  });
+}
+
+function restartApp() {
+  console.log(`[${new Date().toISOString()}] 正在重启应用...`);
+  
+  exec('node index.js', () => {
+    console.log(`[${new Date().toISOString()}] 已尝试重启，继续执行健康检查...`);
+  });
+}
+
+function startChecking() {
+  setInterval(checkPort, CHECK_INTERVAL);
+}
+
+// 启动时开始检查
+startChecking();

--- a/healthCheck.js
+++ b/healthCheck.js
@@ -26,7 +26,7 @@ function checkPort() {
 function restartApp() {
   console.log(`[${new Date().toISOString()}] 正在重启应用...`);
   
-  exec('node index.js', () => {
+  exec('node api/index.js', () => {
     console.log(`[${new Date().toISOString()}] 已尝试重启，继续执行健康检查...`);
   });
 }

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ protos
 cloud_model.json 云端模型的配置文件，请提取unique中的模型使用
 package.json 项目依赖
 vercel.json Vercel部署配置文件
+healthCheck.js 用于自动重启崩溃的主程序
 ```
 # 测试可用模型
 
@@ -98,7 +99,7 @@ vercel.json Vercel部署配置文件
 - **codechat-bison**
 
 # 手动部署
-安装 package.json 中定义的依赖库后，执行 node index.js 启动程序
+安装 package.json 中定义的依赖库后，执行 node index.js 启动程序。若需要自动重启功能，请额外执行 node healthCheck.js
 # 测试命令
 ```
 获取模型
@@ -153,7 +154,18 @@ curl --request POST 'http://127.0.0.1:8787/v1/chat/completions' \
 - **默认值**: 所有模型
 - **获取方式**: `process.env.SUPPORTED_MODELS
 
+## `CHECK_INTERVAL`
+- **描述**: 健康(index.js状态)检查的时间间隔，以秒为单位。
+- **默认值**: `60` 秒
+- **获取方式**: `process.env.CHECK_INTERVAL`
+
 ## Docker 部署说明
+
+x86架构请拉取`chb2024/pieces-os:latest`，arm架构请拉取`chb2024/pieces-os-arm:latest`
+
+docker对于2.0.0以上的版本支持自动重启
+
+以下为x86架构部署示例，arm用户更换镜像即可
 
 ### 使用 Docker Compose（推荐）
 


### PR DESCRIPTION
健康检查 同时构建arm和x86的docker镜像，防止崩溃是之前docker的node轻量版版本不适配的原因，把node:18-slim换成了node20官方版，镜像体积膨胀了5倍(如果仍然容易崩溃，我就换回20的slim)。
崩溃原因仍不明，我比较倾向他们搞黄频率高和超大请求体。
佬可以自己补一下readme